### PR TITLE
Update code structure as per the new requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 composer.lock
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -1,41 +1,47 @@
 {
-  "name": "makeitheady/simplesamlphp-module-mongodb",
-  "description": "A SimpleSAMLphp module to provide a SimpleSAML_Store implementation for MongoDB in PHP 5.5 or higher.",
-  "type": "simplesamlphp-module",
-  "license": "MIT",
-  "keywords": [
-    "simplesamlphp",
-    "modules",
-    "store",
-    "mongodb"
-  ],
-  "authors": [
-    {
-      "name": "Prajyot Khandeparkar",
-      "email": "prajyot@heady.io"
-    },
-    {
-      "name": "Dev",
-      "email": "dev@heady.io",
-      "homepage": "https://www.heady.io/"
-    }
-  ],
-  "require": {
-    "php": "^5.5 || ^5.6 || ^7.0 || ^7.1 || ^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1",
-    "ext-mongodb": "1.*",
-    "simplesamlphp/composer-module-installer": "~1.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": ">=3.70"
-  },
-  "autoload": {
-    "classmap": [
-      "lib"
-    ]
-  },
-  "autoload-dev": {
-    "classmap": [
-      "tests"
-    ]
-  }
+	"name": "makeitheady/simplesamlphp-module-mongodb",
+	"description": "A SimpleSAMLphp module to provide a SimpleSAML_Store implementation for MongoDB in PHP 5.5 or higher.",
+	"type": "simplesamlphp-module",
+	"license": "MIT",
+	"keywords": [
+		"simplesamlphp",
+		"modules",
+		"store",
+		"mongodb"
+	],
+	"authors": [
+		{
+			"name": "Prajyot Khandeparkar",
+			"email": "prajyot@heady.io"
+		},
+		{
+			"name": "Dev",
+			"email": "dev@heady.io",
+			"homepage": "https://www.heady.io/"
+		}
+	],
+	"require": {
+		"php": "^8.1",
+		"simplesamlphp/composer-module-installer": "~1.3.2"
+	},
+	"require-dev": {
+		"simplesamlphp/simplesamlphp": "^2.0.3",
+		"simplesamlphp/simplesamlphp-test-framework": "^1.2.1"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/package-versions-deprecated": true,
+			"simplesamlphp/composer-module-installer": true
+		}
+	},
+	"autoload": {
+		"psr-4": {
+			"SimpleSAML\\Module\\mongodb\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"SimpleSAML\\Test\\Utils\\": "vendor/simplesamlphp/simplesamlphp/tests/Utils"
+		}
+	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
     </php>
     <testsuites>
         <testsuite name="Store Tests">
-            <directory suffix="Test.php">tests/lib/Store</directory>
+            <directory suffix="Test.php">tests/Store</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/Store/fixture/single-host/config.php
+++ b/tests/Store/fixture/single-host/config.php
@@ -1,0 +1,7 @@
+<?php
+
+$config = [
+    'module.enable' => [
+        'mongodb' => true,
+    ],
+];

--- a/tests/Store/fixture/single-host/module_mongodb.php
+++ b/tests/Store/fixture/single-host/module_mongodb.php
@@ -3,10 +3,9 @@
 $config = array(
     'host' => 'localhost',
     'port' => 27017,
-    'username' => '',
-    'password' => '',
-    'database' => 'test'
+    'username' => 'root',
+    'password' => 'password',
+    'database' => 'test',
     'dsn' => '',
     'isReplicaConnectionString' => false
 );
-


### PR DESCRIPTION
As the main module Simplesamlphp has updated their folder structure and structure for custom modules from `v2.x`, this PR will update the structure for Heady's MongoDB module. The following changes are added:

1. Updated folder structure as per Simplesamlphp's new guideline - [Simplesamlphp Modules] (https://simplesamlphp.org/docs/stable/simplesamlphp-modules.html)
2. Updated `composer.json` to use latest versions of required packages
3. Updated unit test cases to make them work with new changes and added new test to check if newly added package works as expected